### PR TITLE
Don't need Jekyll build step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,5 +22,6 @@ jobs:
         with:
           target_branch: gh-pages
           build_dir: docs
+          jekyll: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Turn off the Jekyll build step during GH Pages deploy Action with:
```yaml
with:
   jekyll: false
```